### PR TITLE
Homework 9-2

### DIFF
--- a/course5/homework09_2/CMakeLists.txt
+++ b/course5/homework09_2/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+set(CMAKE_CXX_STANDARD 14)
+
+add_executable(unique_ptr_test main.cc)

--- a/course5/homework09_2/main.cc
+++ b/course5/homework09_2/main.cc
@@ -31,7 +31,6 @@ struct MoreUniquePtr
 			delete ptr;
 	}
 
-	// copy assignment operator
 	MoreUniquePtr& operator=(const MoreUniquePtr& src) = delete; // copy assignmt
 
 	MoreUniquePtr& operator=(MoreUniquePtr&& src) // move assignmt

--- a/course5/homework09_2/main.cc
+++ b/course5/homework09_2/main.cc
@@ -1,0 +1,82 @@
+/*
+Write a simple single-object implementation of std::unique_ptr, complete with make_unique.
+*/
+#include <iostream>
+#include <string>
+#include <cassert>
+
+
+// operators new/delete or new[]/delete[]
+
+template<typename T>
+struct MoreUniquePtr
+{
+	MoreUniquePtr() = default;
+	MoreUniquePtr(const T& src)
+	{
+		ptr = new T;
+		*ptr = src;
+	}
+	MoreUniquePtr(const MoreUniquePtr&) = delete; // copy
+
+	// MoreUniquePtr(MoreUniquePtr&& src) // move
+	// {
+	// 	std::cout << "Move construction" << std::endl;
+	// 	ptr = new T;
+	// 	ptr = src.ptr;
+	// }
+
+	~MoreUniquePtr()
+	{
+		if (ptr)
+			delete ptr;
+	}
+
+	// copy assignment operator
+	MoreUniquePtr& operator=(const MoreUniquePtr& src) = delete; // copy assignmt
+
+	// MoreUniquePtr& operator=(MoreUniquePtr&& src) // move assignmt
+	// {
+	// 	std::cout << "Move assignment" << std::endl;
+	// 	if (ptr)
+	// 		delete ptr;
+	// 	ptr = src.ptr;
+	// }
+
+	T get()
+	{
+		return *ptr;
+	}
+
+private:
+	T * ptr = nullptr;
+};
+
+
+int main(int /*argc*/, char** /*argv*/)
+{
+	MoreUniquePtr<int> default_constructed;
+
+	MoreUniquePtr<int> int_constructor(8);
+	assert(int_constructor.get() == 8);
+	std::cout << "Got " << int_constructor.get() << std::endl;
+
+	std::string yolo = "yolo";
+	MoreUniquePtr<std::string> string_constructor(yolo);
+	std::cout << "Got " << string_constructor.get() << std::endl;
+	assert(std::string(string_constructor.get()) == yolo);
+
+	const char * more_yolo = "more yolo";
+	MoreUniquePtr<const char *> char_star_constructor(more_yolo);
+	std::cout << "Got " << char_star_constructor.get() << std::endl;
+	assert(std::string(char_star_constructor.get()) == "more yolo");
+
+	MoreUniquePtr<double> double_constructor(3.14159);
+	std::cout << "Got " << double_constructor.get() << std::endl;
+	assert(double_constructor.get() == 3.14159);
+
+	// MoreUniquePtr<int> for_move_construction(2);
+	// MoreUniquePtr<int> move_constructed = std::move(for_move_construction);
+	// std::cout << "Got " << move_constructed.get() << std::endl;
+	// assert(move_constructed.get() == 2);
+}

--- a/course5/homework09_2/main.cc
+++ b/course5/homework09_2/main.cc
@@ -19,12 +19,11 @@ struct MoreUniquePtr
 	}
 	MoreUniquePtr(const MoreUniquePtr&) = delete; // copy
 
-	// MoreUniquePtr(MoreUniquePtr&& src) // move
-	// {
-	// 	std::cout << "Move construction" << std::endl;
-	// 	ptr = new T;
-	// 	ptr = src.ptr;
-	// }
+	MoreUniquePtr(MoreUniquePtr&& src) // move
+	{
+		ptr = src.ptr;
+		src.ptr = nullptr;
+	}
 
 	~MoreUniquePtr()
 	{
@@ -35,13 +34,14 @@ struct MoreUniquePtr
 	// copy assignment operator
 	MoreUniquePtr& operator=(const MoreUniquePtr& src) = delete; // copy assignmt
 
-	// MoreUniquePtr& operator=(MoreUniquePtr&& src) // move assignmt
-	// {
-	// 	std::cout << "Move assignment" << std::endl;
-	// 	if (ptr)
-	// 		delete ptr;
-	// 	ptr = src.ptr;
-	// }
+	MoreUniquePtr& operator=(MoreUniquePtr&& src) // move assignmt
+	{
+		if (ptr)
+			delete ptr;
+		ptr = src.ptr;
+		src.ptr = nullptr;
+		return *this;
+	}
 
 	T get()
 	{
@@ -55,6 +55,8 @@ private:
 
 int main(int /*argc*/, char** /*argv*/)
 {
+	/* Test construction/destruction & get method */
+
 	MoreUniquePtr<int> default_constructed;
 
 	MoreUniquePtr<int> int_constructor(8);
@@ -69,14 +71,47 @@ int main(int /*argc*/, char** /*argv*/)
 	const char * more_yolo = "more yolo";
 	MoreUniquePtr<const char *> char_star_constructor(more_yolo);
 	std::cout << "Got " << char_star_constructor.get() << std::endl;
-	assert(std::string(char_star_constructor.get()) == "more yolo");
+	assert(std::string(char_star_constructor.get()) == more_yolo);
 
 	MoreUniquePtr<double> double_constructor(3.14159);
 	std::cout << "Got " << double_constructor.get() << std::endl;
 	assert(double_constructor.get() == 3.14159);
 
-	// MoreUniquePtr<int> for_move_construction(2);
-	// MoreUniquePtr<int> move_constructed = std::move(for_move_construction);
-	// std::cout << "Got " << move_constructed.get() << std::endl;
-	// assert(move_constructed.get() == 2);
+
+	/* Test move assignment between same types */
+
+	MoreUniquePtr<int> for_move_construction(2);
+	MoreUniquePtr<int> move_constructed = std::move(for_move_construction);
+	std::cout << "Got " << move_constructed.get() << std::endl;
+	assert(move_constructed.get() == 2);
+
+	MoreUniquePtr<int> for_move_assignment(3);
+	MoreUniquePtr<int> move_assigned(5);
+	move_assigned = std::move(for_move_assignment);
+	std::cout << "Got " << move_assigned.get() << std::endl;
+	assert(move_assigned.get() == 3);
+
+	/* Test move assignment between types -- shouldn't compile */
+	// MoreUniquePtr<const char *> for_move_construction_combatible_type(more_yolo);
+	// MoreUniquePtr<std::string> move_constructed_combatible_type = std::move(for_move_construction_combatible_type);
+	// std::cout << "Got " << move_constructed_combatible_type.get() << std::endl;
+	// assert(std::string(move_constructed_combatible_type.get()) == more_yolo);
+	//
+	// MoreUniquePtr<const char *> for_move_assignment_combatible_type(more_yolo);
+	// MoreUniquePtr<std::string> move_assigned_combatible_type(yolo);
+	// move_assigned_combatible_type = std::move(for_move_assignment_combatible_type);
+	// std::cout << "Got " << move_assigned_combatible_type.get() << std::endl;
+	// assert(std::string(move_assigned_combatible_type.get()) == more_yolo);
+	//
+	// MoreUniquePtr<std::string> for_move_construction_other_type(yolo);
+	// MoreUniquePtr<double> move_constructed_other_type = std::move(for_move_construction_other_type);
+	// std::cout << "Got " << move_constructed_other_type.get() << std::endl;
+	// assert(std::string(move_constructed_other_type.get()) == yolo);
+	//
+	// MoreUniquePtr<std::string> for_move_assignment_other_type(yolo);
+	// MoreUniquePtr<double> move_assigned_other_type(3.86196357865);
+	// move_assigned_other_type = std::move(for_move_assignment_other_type);
+	// std::cout << "Got " << move_assigned_other_type.get() << std::endl;
+	// assert(std::string(move_assigned_other_type.get()) == yolo);
+
 }


### PR DESCRIPTION
It works with no memory leaks for the given tests.

I wasn't kind of surprised to find that move construction/assignment from instances w type of `const char *` to instances w type `std::string` didn't compile.